### PR TITLE
Disable expensive builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         os:
          - ubuntu-latest
-         - windows-latest
-         - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Remove windows and macOS due to run costs for builds